### PR TITLE
agriculture: fix a minor issue when checking the farm connectivity state

### DIFF
--- a/agriculture/agriculturecore/templates/sidebar.html
+++ b/agriculture/agriculturecore/templates/sidebar.html
@@ -197,9 +197,6 @@
         // Get the weather condition and time factor from the irrigation controller.
         getWeatherCondition();
         getTimeFactor();
-
-        // Check farm connectivity in 5 secs.
-        setTimeout(checkFarmConnected, 5000, "schedule");
     });
 
     // Sets the selected section.

--- a/agriculture/static/js/sidebar.js
+++ b/agriculture/static/js/sidebar.js
@@ -123,6 +123,8 @@ function updateFarmConnectionStatus(response) {
         farmConnectionStatus = response["status"];
     }
 
+    checkFarmConnected();
+
     // Schedule a new connection status update in 30 seconds.
     setTimeout(checkFarmConnectionStatus, 30000);
 }
@@ -142,6 +144,4 @@ function checkFarmConnected() {
             showPopup($(".water-tank-card"), $("#popup-info-tank"));
     }
     prevFarmConnectionStatus = farmConnectionStatus;
-
-    setTimeout(checkFarmConnected, 5000);
 }


### PR DESCRIPTION
In slow networks, the request to check if the farm is online or not was
finishing after updating the UI, making it to get the default values and
showing that the farm was offline.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>