### PR TITLE
agriculture: improve the error handling in Python and Javascript

### DIFF
--- a/agriculture/agriculturecore/drm_requests.py
+++ b/agriculture/agriculturecore/drm_requests.py
@@ -67,6 +67,8 @@ ID_STATIONS = "stations"
 ID_WEATHER = "weather"
 ID_TANK = "tank"
 
+ID_ERROR = "error"
+
 REGEX_DEV_REQUEST_RESPONSE = ".*<device_request .*>(.*)<\\/device_request>.*"
 REGEX_DO_CMD_RESPONSE = ".*<do_command target=[^>]*>(.*)<\\/do_command>.*"
 
@@ -144,6 +146,41 @@ def get_device_cloud_session(session):
                        base_url=user_serialized.server)
 
 
+def check_ajax_request(request):
+    """
+    Checks whether the given AJAX request is valid and the user is
+    authenticated.
+
+    Args:
+        request (:class:`.WSGIRequest`): The HTTP request.
+
+    Returns:
+        `None` if the request is valid, or a `JsonResponse` with the error
+            if it is not.
+    """
+    if is_authenticated(request):
+        if not request.is_ajax or request.method != "POST":
+            return JsonResponse({ID_ERROR: "AJAX request must be sent using POST"}, status=400)
+        return None
+    else:
+        return JsonResponse({ID_ERROR: "Not authenticated"}, status=401)
+
+
+def get_exception_response(e):
+    """
+    Returns the JSON response with the error contained in the given exception.
+
+    Args:
+        e (:class:`.Exception`): The exception.
+
+    Returns:
+        A JSON response with the details of the exception.
+    """
+    return JsonResponse({ID_ERROR: ("Error in the DRM request: {}.".format(e.response.text)
+                                    if isinstance(e, DeviceCloudHttpException) else str(e))},
+                        status=400)
+
+
 def send_device_request(request, target):
     """
     Sends a Device Request to DRM to the device with the given ID.
@@ -155,13 +192,12 @@ def send_device_request(request, target):
     Returns:
         A JSON with the response or the error.
     """
-    if not request.is_ajax or request.method != "POST":
-        return JsonResponse({"error": "AJAX request must be sent using POST"},
-                            status=400)
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     dc = get_device_cloud(request)
-    if dc is None:
-        return JsonResponse({"error": "Invalid credentials."}, status=400)
 
     device_id = request.POST[views.PARAM_CONTROLLER_ID]
     data = request.POST[PARAM_DATA] if PARAM_DATA in request.POST else None
@@ -172,9 +208,7 @@ def send_device_request(request, target):
             return JsonResponse({"data": resp}, status=200)
         return JsonResponse({"valid": True}, status=200)
     except DeviceCloudHttpException as e:
-        return JsonResponse(
-            {"error": "Error in the DRM request: {}.".format(e.response.text)},
-            status=e.response.status_code)
+        return get_exception_response(e)
 
 
 def send_request(dc, device_id, target, data=None):
@@ -530,13 +564,12 @@ def get_data_points(request, stream_name):
     Returns:
         A JSON with the data points or the error.
     """
-    if not request.is_ajax or request.method != "POST":
-        return JsonResponse({"error": "AJAX request must be sent using POST"},
-                            status=400)
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     dc = get_device_cloud(request)
-    if dc is None:
-        return JsonResponse({"error": "Invalid credentials."}, status=400)
 
     device_id = request.POST[views.PARAM_CONTROLLER_ID]
     interval = int(

--- a/agriculture/agriculturecore/templates/map.html
+++ b/agriculture/agriculturecore/templates/map.html
@@ -52,7 +52,9 @@ Digi Demo - Map
         $.post(
             "{% url 'get_smart_farms' %}",
             getSmartFarmsCallback
-        );
+        ).fail(function(response) {
+            processErrorResponse(response);
+        });
 
         // Initialize the map.
         initMap();

--- a/agriculture/agriculturecore/templates/sidebar.html
+++ b/agriculture/agriculturecore/templates/sidebar.html
@@ -240,7 +240,9 @@
                 if (data["redirect"])
                     window.location.replace(data["redirect"]);
             }
-        );
+        ).fail(function(response) {
+            processErrorResponse(response);
+        });
     }
     </script>
 {% endblock %}

--- a/agriculture/agriculturecore/views.py
+++ b/agriculture/agriculturecore/views.py
@@ -19,7 +19,6 @@ from agriculturecore.drm_requests import *
 PARAM_CONTROLLER_ID = "controller_id"
 PARAM_FARM_NAME = "farm_name"
 
-ID_ERROR = "error"
 ID_ERROR_TITLE = "error_title"
 ID_ERROR_MSG = "error_msg"
 ID_ERROR_GUIDE = "error_guide"
@@ -253,13 +252,10 @@ def get_smart_farms(request):
         :class:`.JsonResponse`: A JSON response with the list of the Smart
             Farms within the DRM account.
     """
-    if is_authenticated(request):
-        if not request.is_ajax or request.method != "POST":
-            return JsonResponse(
-                {"error": "AJAX request must be sent using POST"},
-                status=400)
-    else:
-        return redirect('/access/login')
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     smart_farms = get_farms(request)
     if len(smart_farms) > 0:
@@ -287,13 +283,10 @@ def get_irrigation_stations(request):
             Stations corresponding to the controller with the ID provided in
             the request.
     """
-    if is_authenticated(request):
-        if not request.is_ajax or request.method != "POST":
-            return JsonResponse(
-                {"error": "AJAX request must be sent using POST"},
-                status=400)
-    else:
-        return redirect('/access/login')
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     # Get the controller ID from the POST request.
     controller_id = request.POST[PARAM_CONTROLLER_ID]
@@ -308,7 +301,7 @@ def get_irrigation_stations(request):
                                  ID_ERROR_MSG: NO_STATIONS_MSG,
                                  ID_ERROR_GUIDE: SETUP_MODULES_GUIDE})
     except DeviceCloudHttpException as e:
-        return JsonResponse({ID_ERROR: str(e)})
+        return get_exception_response(e)
 
 
 def get_farm_status(request):
@@ -322,13 +315,10 @@ def get_farm_status(request):
     Returns:
         :class:`.JsonResponse`: A JSON response with the status of the farm.
     """
-    if is_authenticated(request):
-        if not request.is_ajax or request.method != "POST":
-            return JsonResponse(
-                {"error": "AJAX request must be sent using POST"},
-                status=400)
-    else:
-        return redirect('/access/login')
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     try:
         # Get the controller ID from the POST request.
@@ -362,7 +352,7 @@ def get_farm_status(request):
 
         return JsonResponse(farm_status, status=200)
     except Exception as e:
-        return JsonResponse({ID_ERROR: str(e)})
+        return get_exception_response(e)
 
 
 def set_valve(request):
@@ -376,13 +366,10 @@ def set_valve(request):
     Returns:
         :class:`.JsonResponse`: A JSON response with the set status.
     """
-    if is_authenticated(request):
-        if not request.is_ajax or request.method != "POST":
-            return JsonResponse(
-                {"error": "AJAX request must be sent using POST"},
-                status=400)
-    else:
-        return redirect('/access/login')
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     # Get the controller ID and irrigation station from the POST request.
     data = json.loads(request.body.decode(request.encoding))
@@ -393,7 +380,7 @@ def set_valve(request):
     new_value = set_valve_value(request, controller_id, station_id, value)
     if new_value is not None:
         return JsonResponse({"value": new_value}, status=200)
-    return JsonResponse({"error": "Could not set the valve."}, status=400)
+    return JsonResponse({ID_ERROR: "Could not set the valve."}, status=400)
 
 
 def set_tank_valve(request):
@@ -407,13 +394,10 @@ def set_tank_valve(request):
     Returns:
         :class:`.JsonResponse`: A JSON response with the set status.
     """
-    if is_authenticated(request):
-        if not request.is_ajax or request.method != "POST":
-            return JsonResponse(
-                {"error": "AJAX request must be sent using POST"},
-                status=400)
-    else:
-        return redirect('/access/login')
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     # Get the controller ID and status of the valve from the POST request.
     data = json.loads(request.body.decode(request.encoding))
@@ -423,7 +407,7 @@ def set_tank_valve(request):
     new_value = set_tank_valve_value(request, controller_id, value)
     if new_value is not None:
         return JsonResponse({"value": new_value}, status=200)
-    return JsonResponse({"error": "Could not set the valve."}, status=400)
+    return JsonResponse({ID_ERROR: "Could not set the valve."}, status=400)
 
 
 def refill_tank(request):
@@ -437,13 +421,10 @@ def refill_tank(request):
     Returns:
         :class:`.JsonResponse`: A JSON response with the set status.
     """
-    if is_authenticated(request):
-        if not request.is_ajax or request.method != "POST":
-            return JsonResponse(
-                {"error": "AJAX request must be sent using POST"},
-                status=400)
-    else:
-        return redirect('/access/login')
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     # Get the controller ID and level of the tank from the POST request.
     data = json.loads(request.body.decode(request.encoding))
@@ -452,7 +433,7 @@ def refill_tank(request):
     new_value = refill_tank_request(request, controller_id)
     if new_value is not None:
         return JsonResponse({"value": new_value}, status=200)
-    return JsonResponse({"error": "Could not set the valve."}, status=400)
+    return JsonResponse({ID_ERROR: "Could not set the valve."}, status=400)
 
 
 def get_request_data(request):
@@ -563,13 +544,10 @@ def check_farm_connection_status(request):
     Returns:
         A JSON with the status of the farm or the error.
     """
-    if is_authenticated(request):
-        if not request.is_ajax or request.method != "POST":
-            return JsonResponse(
-                {"error": "AJAX request must be sent using POST"},
-                status=400)
-    else:
-        return redirect('/access/login')
+    # Check if the AJAX request is valid.
+    error = check_ajax_request(request)
+    if error is not None:
+        return error
 
     # Get the controller ID and irrigation station from the POST request.
     data = json.loads(request.body.decode(request.encoding))

--- a/agriculture/static/js/dashboard.js
+++ b/agriculture/static/js/dashboard.js
@@ -263,7 +263,9 @@ function getFarmStatus(first=true) {
                 return;
             processFarmStatusResponse(data, first);
         }
-    );
+    ).fail(function(response) {
+        processErrorResponse(response);
+    });
 }
 
 // Processes the response of the farm status request.
@@ -709,7 +711,9 @@ function toggleValve(stationID) {
             if (isValveON(stationID) && !isTankValveON())
                 toggleTankValve();
         }
-    );
+    ).fail(function(response) {
+        processErrorResponse(response);
+    });
 }
 
 // Updates the status of the valve with the given ID.
@@ -821,7 +825,9 @@ function refillTank() {
             waterLevel = data["value"];
             updateWaterTankLevel();
         }
-    );
+    ).fail(function(response) {
+        processErrorResponse(response);
+    });
 }
 
 // Updates the status of the tank valve toggle button.
@@ -881,7 +887,9 @@ function toggleTankValve() {
                 }
             }
         }
-    );
+    ).fail(function(response) {
+        processErrorResponse(response);
+    });
 }
 
 // Returns the number of irrigating stations.

--- a/agriculture/static/js/history.js
+++ b/agriculture/static/js/history.js
@@ -183,6 +183,8 @@ function drawWindChart(refresh=false, showProgress=false) {
             windData = response.data;
             drawWindChart();
             $("#wind-chart-loading").hide();
+        }).fail(function(response) {
+            processErrorResponse(response);
         });
     } else {
         drawChart("wind-chart", windData, "Wind", "km/h", "#4F4F4F");
@@ -198,6 +200,8 @@ function drawRainChart(refresh=false, showProgress=false) {
             rainData = response.data;
             drawRainChart();
             $("#rain-chart-loading").hide();
+        }).fail(function(response) {
+            processErrorResponse(response);
         });
     } else {
         drawChart("rain-chart", rainData, "Rain", "mm", "#3399FF");
@@ -213,6 +217,8 @@ function drawRadiationChart(refresh=false, showProgress=false) {
             radiationData = response.data;
             drawRadiationChart();
             $("#radiation-chart-loading").hide();
+        }).fail(function(response) {
+            processErrorResponse(response);
         });
     } else {
         drawChart("radiation-chart", radiationData, "Radiation", "W/m2", "#FFD500");
@@ -228,6 +234,8 @@ function drawTemperatureChart(macAddr, refresh=false, showProgress=false) {
             temperatureData[macAddr] = response.data;
             drawTemperatureChart(macAddr);
             $("#temperature-" + macAddr + "-chart-loading").hide();
+        }).fail(function(response) {
+            processErrorResponse(response);
         });
     } else {
         drawChart("temperature-" + macAddr + "-chart", temperatureData[macAddr], "Temperature", "ºC", "#FF0000");
@@ -243,6 +251,8 @@ function drawMoistureChart(macAddr, refresh=false, showProgress=false) {
             moistureData[macAddr] = response.data;
             drawMoistureChart(macAddr);
             $("#moisture-" + macAddr + "-chart-loading").hide();
+        }).fail(function(response) {
+            processErrorResponse(response);
         });
     } else {
         drawChart("moisture-" + macAddr + "-chart", moistureData[macAddr], "Moisture", "%", "#33CC66");
@@ -258,6 +268,8 @@ function drawValveChart(macAddr, refresh=false, showProgress=false) {
             valveData[macAddr] = response.data;
             drawValveChart(macAddr);
             $("#valve-" + macAddr + "-chart-loading").hide();
+        }).fail(function(response) {
+            processErrorResponse(response);
         });
     } else {
         drawChart("valve-" + macAddr + "-chart", valveData[macAddr], "Valve", "Closed/Open", "#0000CC");
@@ -341,6 +353,8 @@ function drawStationsCharts() {
             drawMoistureChart(macAddr, true, true);
             drawValveChart(macAddr, true, true);
         }
+    }).fail(function(response) {
+        processErrorResponse(response);
     });
 }
 

--- a/agriculture/static/js/schedule.js
+++ b/agriculture/static/js/schedule.js
@@ -94,6 +94,8 @@ function initSchedule() {
         e.preventDefault();
         $.post("/ajax/set_schedule", getJsonData(tableToJson()), function(response) {
             $this.html($this.data("original-text"));
+        }).fail(function(response) {
+            processErrorResponse(response);
         });
     });
 
@@ -127,6 +129,8 @@ function getSchedule() {
         hideLoadingPanel();
         // Show the schedule container.
         $("#schedule-container").show();
+    }).fail(function(response) {
+        processErrorResponse(response);
     });
 }
 

--- a/agriculture/static/js/sidebar.js
+++ b/agriculture/static/js/sidebar.js
@@ -145,3 +145,24 @@ function checkFarmConnected() {
     }
     prevFarmConnectionStatus = farmConnectionStatus;
 }
+
+// Processes the error response of the AJAX request.
+function processErrorResponse(response) {
+    if (response.status == 400) {
+        let errorMessage = response.responseJSON["error"];
+        // Show the error message (if any).
+        if (errorMessage != null)
+            toastr.error(errorMessage);
+    } else if (response.status == 401) {
+        redirectToLogin();
+    }
+}
+
+// Redirects to the login page.
+function redirectToLogin() {
+    var url = "/access/login?dest=" + window.location.pathname.replaceAll("/", "");
+    var params = new URLSearchParams(window.location.search);
+    for (let param of params)
+        url += "&" + param[0] + "=" + param[1];
+    window.location.href = url;
+}

--- a/agriculture/static/js/widgets.js
+++ b/agriculture/static/js/widgets.js
@@ -28,6 +28,8 @@ function setWeatherCondition(e) {
     $.post("/ajax/set_condition", getJsonData(selected)).fail(function(response) {
         // If the operation fails, get the real condition.
         getWeatherCondition();
+    }).fail(function(response) {
+        processErrorResponse(response);
     });
 }
 
@@ -38,6 +40,8 @@ function getWeatherCondition() {
     $.post("/ajax/get_condition", getJsonData(), function(response) {
         var resp = response["data"];
         selectWeatherIcon(resp);
+    }).fail(function(response) {
+        processErrorResponse(response);
     });
 }
 
@@ -55,6 +59,8 @@ function setTimeFactor(e) {
     $.post("/ajax/set_factor", getJsonData(selected)).fail(function(response) {
         // If the operation fails, get the real factor.
         getTimeFactor();
+    }).fail(function(response) {
+        processErrorResponse(response);
     });
 }
 
@@ -66,6 +72,8 @@ function getTimeFactor() {
             selectTimeIcon(currentTimeFactor);
             getCurrentTime();
         }
+    }).fail(function(response) {
+        processErrorResponse(response);
     });
 }
 
@@ -80,6 +88,8 @@ function getCurrentTime() {
             };
             timeWorker.postMessage(currentTime + "@@@" + currentTimeFactor);
         }
+    }).fail(function(response) {
+        processErrorResponse(response);
     });
 }
 


### PR DESCRIPTION
All AJAX requests define now a callback for the errors. If it is a 400,
the web shows a popup with the error message. If it is a 401, it redirects
to the login page.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>